### PR TITLE
Fix oωo-lib Conflict Prevents Stacking in Furnaces

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -12,6 +12,7 @@ repositories {
     // Loom adds the essential maven repositories to download Minecraft and libraries from automatically.
     // See https://docs.gradle.org/current/userguide/declaring_repositories.html
     // for more information about repositories.
+    maven { url 'https://maven.wispforest.io' }
 }
 
 loom {
@@ -37,6 +38,7 @@ dependencies {
     // Fabric API. This is technically optional, but you probably want it anyway.
     modImplementation "net.fabricmc.fabric-api:fabric-api:${project.fabric_version}"
 
+    modCompileOnly "io.wispforest:owo-lib:${project.owo_version}"
 }
 
 
@@ -79,7 +81,7 @@ java {
 
 jar {
     from("LICENSE") {
-        rename { "${it}_${project.archivesBaseName}"}
+        rename { "${it}_${project.archivesBaseName}" }
     }
 }
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -15,3 +15,4 @@ org.gradle.jvmargs=-Xmx1G
 #Dependencies
 	# check this on https://fabricmc.net/develop/
 	fabric_version=0.100.7+1.21
+	owo_version=0.12.15+1.21

--- a/src/main/java/com/boyonk/itemcomponents/ItemComponents.java
+++ b/src/main/java/com/boyonk/itemcomponents/ItemComponents.java
@@ -3,6 +3,7 @@ package com.boyonk.itemcomponents;
 import net.fabricmc.api.ModInitializer;
 import net.fabricmc.fabric.api.event.lifecycle.v1.ServerLifecycleEvents;
 import net.fabricmc.fabric.api.resource.ResourceManagerHelper;
+import net.fabricmc.loader.api.FabricLoader;
 import net.minecraft.item.ItemStack;
 import net.minecraft.resource.ResourceType;
 import org.slf4j.Logger;
@@ -20,13 +21,16 @@ public class ItemComponents implements ModInitializer {
 
 	public static final ItemComponentsManager MANAGER = new ItemComponentsManager();
 
-
 	private static final Set<ItemStack> WEAK_STACKS = Collections.synchronizedSet(Collections.newSetFromMap(new WeakHashMap<>()));
+
+	private static boolean owoHack = false;
 
 	@Override
 	public void onInitialize() {
 		ResourceManagerHelper.get(ResourceType.SERVER_DATA).registerReloadListener(MANAGER);
 		ServerLifecycleEvents.SERVER_STOPPED.register(server -> MANAGER.close());
+
+		if (FabricLoader.getInstance().isModLoaded("owo")) owoHack = true;
 	}
 
 	public static void store(ItemStack stack) {
@@ -38,5 +42,10 @@ public class ItemComponents implements ModInitializer {
 			WEAK_STACKS.forEach(action);
 		}
 	}
+
+	public static boolean applyOwoHack() {
+		return owoHack;
+	}
+
 
 }

--- a/src/main/java/com/boyonk/itemcomponents/OwoHack.java
+++ b/src/main/java/com/boyonk/itemcomponents/OwoHack.java
@@ -1,0 +1,14 @@
+package com.boyonk.itemcomponents;
+
+import io.wispforest.owo.ext.DerivedComponentMap;
+import net.minecraft.component.ComponentMap;
+import net.minecraft.item.ItemStack;
+
+public class OwoHack {
+
+	public static ComponentMap apply(ItemStack stack, ComponentMap map) {
+		DerivedComponentMap derived = new DerivedComponentMap(map);
+		derived.derive(stack);
+		return derived;
+	}
+}

--- a/src/main/java/com/boyonk/itemcomponents/mixin/ItemStackMixin.java
+++ b/src/main/java/com/boyonk/itemcomponents/mixin/ItemStackMixin.java
@@ -2,6 +2,7 @@ package com.boyonk.itemcomponents.mixin;
 
 import com.boyonk.itemcomponents.BaseComponentSetter;
 import com.boyonk.itemcomponents.ItemComponents;
+import com.boyonk.itemcomponents.OwoHack;
 import net.minecraft.component.ComponentMap;
 import net.minecraft.component.ComponentMapImpl;
 import net.minecraft.item.ItemConvertible;
@@ -9,9 +10,12 @@ import net.minecraft.item.ItemStack;
 import org.spongepowered.asm.mixin.Final;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.Unique;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+import java.lang.reflect.Field;
 
 @Mixin(ItemStack.class)
 public abstract class ItemStackMixin implements BaseComponentSetter {
@@ -27,7 +31,22 @@ public abstract class ItemStackMixin implements BaseComponentSetter {
 
 	@Override
 	public void itemcomponents$setBaseComponents(ComponentMap baseComponents) {
+		if (ItemComponents.applyOwoHack()) baseComponents = this.itemcomponents$owoHack(baseComponents);
+
 		((BaseComponentSetter) (Object) this.components).itemcomponents$setBaseComponents(baseComponents);
+	}
+
+	@Unique
+	private ComponentMap itemcomponents$owoHack(ComponentMap base) {
+		try {
+			Field field = ItemStack.class.getDeclaredField("owo$derivedMap");
+			ComponentMap derived = OwoHack.apply((ItemStack) (Object) this, base);
+			field.set(this, derived);
+			return derived;
+		} catch (Exception e) {
+			ItemComponents.LOGGER.error("Failed to wrap owo: ", e);
+			throw new RuntimeException(e);
+		}
 	}
 
 }


### PR DESCRIPTION
Fixes #2

The issue was caused by `AbstractFurnaceBlockEntity#canAcceptRecipeOutput`, calling `ItemStack#areItemsAndComponentsEqual`, which compares the equality of both stacks `components` field. Because oωo-lib wraps the `ComponentMapImpl.base` in `DerivedComponentMap` on an `ItemStack`, and `DerivedComponentMap#equals` does not allow object to be a different class, the components are not deemed equal.


Note that this is a relatively hacky/improper fix. oωo-lib and Item Components are both trying to do something that they shouldn't; modifying the immutability of the base of a `ComponentMapImpl`.
Obviously from my perspective, there is good reasons for Item Components to do this. Looking at oωo-lib's code, I couldn't fully understand why they need to, but I'm confident they have proper reasoning too.
My uneducated suggestion to a more proper fix would be for oωo-lib to consider allowing `DerivedComponentMap#equals` to return true, even when the compared object isn't `DerivedComponentMap`.


This hack works in the following way:
1. In `ItemComponents#onInitialize `if oωo-lib is present, set `ItemComponents.owoHack` to true.
2. In `ItemStackMixin#itemcomponents$setBaseComponents`, before calling `itemcomponents$setBaseComponents` on the `ComponentMapImpl`, if `ItemComponents#applyOwoHack`, wrap the argument `baseComponents `using `ItemStackMixin#itemcomponents$owoHack`
3. `ItemStackMixin#itemcomponents$owoHack` calls `OwoHack#apply` where it is wrapped in `DerivedComponentMap` and `DerivedComponentMap#derive` is called with the `ItemStack`. We do this in a separate class as to not import `DerivedComponentMap `into our `ItemStackMixin`, so instances without oωo-lib won't get a `ClassNotFoundException`.


