### PR TITLE
Fix support for datapacks that rely on tags (e.g. "stackable" datapacks)

### DIFF
--- a/src/main/java/com/boyonk/itemcomponents/ItemComponents.java
+++ b/src/main/java/com/boyonk/itemcomponents/ItemComponents.java
@@ -1,6 +1,7 @@
 package com.boyonk.itemcomponents;
 
 import net.fabricmc.api.ModInitializer;
+import net.fabricmc.fabric.api.event.lifecycle.v1.CommonLifecycleEvents;
 import net.fabricmc.fabric.api.event.lifecycle.v1.ServerLifecycleEvents;
 import net.fabricmc.fabric.api.resource.ResourceManagerHelper;
 import net.fabricmc.loader.api.FabricLoader;
@@ -28,6 +29,7 @@ public class ItemComponents implements ModInitializer {
 	@Override
 	public void onInitialize() {
 		ResourceManagerHelper.get(ResourceType.SERVER_DATA).registerReloadListener(MANAGER);
+		CommonLifecycleEvents.TAGS_LOADED.register(MANAGER);
 		ServerLifecycleEvents.SERVER_STOPPED.register(server -> MANAGER.close());
 
 		if (FabricLoader.getInstance().isModLoaded("owo")) owoHack = true;


### PR DESCRIPTION
Fixes #5

This fixes all datapacks such as `stackable_shulker_boxes` and `stackable_potions` which use tag targets.

Tag targets like `#minecraft:shulker_boxes` aren't resolved on the initial reload because tags aren't applied to the registry entries until after pack reloading is complete. Thus, component changes that target tags are only applied once the `/reload` command is used, at which point the tags have already been populated.

By deferring resolution until the `TAGS_LOADED` event occurs (which always occurs after resource pack reload), we ensure the most up-to-date tags are available.