### PR TITLE
Fix Data Component Types using Codecs that rely RegistryOps fail 

### DIFF
--- a/src/main/java/com/boyonk/itemcomponents/ItemComponents.java
+++ b/src/main/java/com/boyonk/itemcomponents/ItemComponents.java
@@ -28,8 +28,13 @@ public class ItemComponents implements ModInitializer {
 
 	@Override
 	public void onInitialize() {
-		ResourceManagerHelper.get(ResourceType.SERVER_DATA).registerReloadListener(MANAGER);
-		CommonLifecycleEvents.TAGS_LOADED.register((registries, client) -> { if (!client) MANAGER.resolve(); });
+		ResourceManagerHelper.get(ResourceType.SERVER_DATA).registerReloadListener(MANAGER.getFabricId(), (registries) -> {
+			MANAGER.setRegistries(registries);
+			return MANAGER;
+		});
+		CommonLifecycleEvents.TAGS_LOADED.register((registries, client) -> {
+			if (!client) MANAGER.resolve();
+		});
 		ServerLifecycleEvents.SERVER_STOPPED.register(server -> MANAGER.close());
 
 		if (FabricLoader.getInstance().isModLoaded("owo")) owoHack = true;


### PR DESCRIPTION
Fixes #6

This fixes all data component types that have codecs in them that rely on RegistryOps.

We use ```ResourceManagerHelper#registerReloadListener(identifier,listenerFactory)``` to now pass ```RegistryWrapper.WrapperLookup``` to ```ItemComponentsManager```